### PR TITLE
Implement bitwise operators, binary shifts and comparisons

### DIFF
--- a/concrete/numpy/compilation/compiler.py
+++ b/concrete/numpy/compilation/compiler.py
@@ -439,7 +439,11 @@ class Compiler:
             self._evaluate("Compiling", inputset)
             assert self.graph is not None
 
-            mlir = GraphConverter.convert(self.graph, virtual=self.configuration.virtual)
+            mlir = GraphConverter.convert(
+                self.graph,
+                virtual=self.configuration.virtual,
+                node_converter_configuration=self.configuration.node_converter_configuration,
+            )
             if self.artifacts is not None:
                 self.artifacts.add_mlir_to_compile(mlir)
 

--- a/concrete/numpy/compilation/configuration.py
+++ b/concrete/numpy/compilation/configuration.py
@@ -10,6 +10,17 @@ DEFAULT_P_ERROR = None
 DEFAULT_GLOBAL_P_ERROR = 1 / 100_000
 
 
+class NodeConverterConfiguration:
+    """
+    Configuration to describe how to emit low-level MLIR operators.
+    It provides default values to different hyper-parameters, which
+    be overriden depending on the context.
+    """
+
+    def __init__(self, split_in_n_group_of_bits=2):
+        self.split_in_n_group_of_bits = split_in_n_group_of_bits
+
+
 class Configuration:
     """
     Configuration class, to allow the compilation process to be customized.
@@ -33,6 +44,7 @@ class Configuration:
     global_p_error: Optional[float]
     insecure_key_cache_location: Optional[str]
     auto_adjust_rounders: bool
+    node_converter_configuration: NodeConverterConfiguration
 
     # pylint: enable=too-many-instance-attributes
 
@@ -75,6 +87,7 @@ class Configuration:
         p_error: Optional[float] = None,
         global_p_error: Optional[float] = None,
         auto_adjust_rounders: bool = False,
+        node_converter_configuration: Optional[NodeConverterConfiguration] = None,
     ):
         self.verbose = verbose
         self.show_graph = show_graph
@@ -94,6 +107,10 @@ class Configuration:
         self.p_error = p_error
         self.global_p_error = global_p_error
         self.auto_adjust_rounders = auto_adjust_rounders
+        if node_converter_configuration is not None:
+            self.node_converter_configuration = node_converter_configuration
+        else:
+            self.node_converter_configuration = NodeConverterConfiguration()
 
         self._validate()
 

--- a/concrete/numpy/mlir/graph_converter.py
+++ b/concrete/numpy/mlir/graph_converter.py
@@ -24,6 +24,7 @@ from mlir.ir import (
     RankedTensorType,
 )
 
+from ..compilation.configuration import NodeConverterConfiguration
 from ..dtypes import Integer, SignedInteger
 from ..internal.utils import assert_that
 from ..representation import Graph, Node, Operation
@@ -613,7 +614,11 @@ class GraphConverter:
         return sanitized_args
 
     @staticmethod
-    def convert(graph: Graph, virtual: bool = False) -> str:
+    def convert(
+        graph: Graph,
+        virtual: bool = False,
+        node_converter_configuration: NodeConverterConfiguration = None,
+    ) -> str:
         """
         Convert a computation graph to its corresponding MLIR representation.
 
@@ -674,6 +679,9 @@ class GraphConverter:
                             preds,
                             constant_cache,
                             from_elements_operations,
+                            node_converter_configuration
+                            if node_converter_configuration
+                            else NodeConverterConfiguration(),
                         )
                         ir_to_mlir[node] = node_converter.convert()
 

--- a/concrete/numpy/mlir/graph_converter.py
+++ b/concrete/numpy/mlir/graph_converter.py
@@ -170,6 +170,14 @@ class GraphConverter:
             elif name == "zeros":
                 assert_that(len(inputs) == 0)
 
+            elif name == "bitwise_and":
+                assert_that(len(inputs) == 2)
+
+            elif name == "bitwise_or":
+                assert_that(len(inputs) == 2)
+
+            elif name == "bitwise_xor":
+                assert_that(len(inputs) == 2)
             else:
                 assert_that(node.converted_to_table_lookup)
                 variable_input_indices = [

--- a/concrete/numpy/mlir/graph_converter.py
+++ b/concrete/numpy/mlir/graph_converter.py
@@ -178,6 +178,25 @@ class GraphConverter:
 
             elif name == "bitwise_xor":
                 assert_that(len(inputs) == 2)
+
+            elif name == "less":
+                assert_that(len(inputs) == 2)
+
+            elif name == "less_equal":
+                assert_that(len(inputs) == 2)
+
+            elif name == "greater":
+                assert_that(len(inputs) == 2)
+
+            elif name == "greater_equal":
+                assert_that(len(inputs) == 2)
+
+            elif name == "equal":
+                assert_that(len(inputs) == 2)
+
+            elif name == "not_equal":
+                assert_that(len(inputs) == 2)
+
             else:
                 assert_that(node.converted_to_table_lookup)
                 variable_input_indices = [

--- a/concrete/numpy/mlir/graph_converter.py
+++ b/concrete/numpy/mlir/graph_converter.py
@@ -197,6 +197,12 @@ class GraphConverter:
             elif name == "not_equal":
                 assert_that(len(inputs) == 2)
 
+            elif name == "left_shift":
+                assert_that(len(inputs) == 2)
+
+            elif name == "right_shift":
+                assert_that(len(inputs) == 2)
+
             else:
                 assert_that(node.converted_to_table_lookup)
                 variable_input_indices = [

--- a/concrete/numpy/mlir/node_converter.py
+++ b/concrete/numpy/mlir/node_converter.py
@@ -213,6 +213,10 @@ class NodeConverter:
         return self._convert_tlu()
 
     def _1d_lut(self, resulting_type, pred, lut_values) -> OpResult:
+        # If the lut is the identity then we can skip it.
+        if all(i == lut_values[i] for i in range(0, len(lut_values))):
+            return pred
+
         lut_type = RankedTensorType.get(
             (len(lut_values),), IntegerType.get_signless(64, context=self.ctx)
         )

--- a/concrete/numpy/representation/node.py
+++ b/concrete/numpy/representation/node.py
@@ -378,6 +378,8 @@ class Node:
                 "greater_equal",
                 "equal",
                 "not_equal",
+                "left_shift",
+                "right_shift",
             ]
         ):
             return False

--- a/concrete/numpy/representation/node.py
+++ b/concrete/numpy/representation/node.py
@@ -372,6 +372,12 @@ class Node:
                 "bitwise_or",
                 "bitwise_and",
                 "bitwise_xor",
+                "less",
+                "less_equal",
+                "greater",
+                "greater_equal",
+                "equal",
+                "not_equal",
             ]
         ):
             return False

--- a/concrete/numpy/representation/node.py
+++ b/concrete/numpy/representation/node.py
@@ -362,7 +362,19 @@ class Node:
             bool:
                 True if the node is converted to a table lookup, False otherwise
         """
-
+        # nodes with more than two encrypted operands can't get fused
+        encrypted_inputs = [i for i in self.inputs if i.is_encrypted]
+        if (
+            len(encrypted_inputs) > 1
+            and self.operation == Operation.Generic
+            and self.properties["name"]
+            in [
+                "bitwise_or",
+                "bitwise_and",
+                "bitwise_xor",
+            ]
+        ):
+            return False
         return self.operation == Operation.Generic and self.properties["name"] not in [
             "add",
             "array",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ from typing import Any, Callable, Dict, List, Tuple, Union
 import numpy as np
 import pytest
 
+from concrete.numpy.compilation.configuration import NodeConverterConfiguration
 import concrete.numpy as cnp
 import tests
 
@@ -117,6 +118,7 @@ class Helpers:
             jit=True,
             insecure_key_cache_location=INSECURE_KEY_CACHE_LOCATION,
             global_p_error=(1 / 10_000),
+            node_converter_configuration=NodeConverterConfiguration(2),
         )
 
     @staticmethod

--- a/tests/execution/test_bitwise.py
+++ b/tests/execution/test_bitwise.py
@@ -1,0 +1,126 @@
+"""
+Tests of execution of add operation.
+"""
+
+import pytest
+
+import concrete.numpy as cnp
+
+
+@pytest.mark.parametrize(
+    "function",
+    [
+        pytest.param(
+            lambda x, y: x | y,
+            id="x | y",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "parameters",
+    [
+        {
+            "x": {"range": [0, 31], "status": "encrypted"},
+            "y": {"range": [0, 31], "status": "encrypted"},
+        },
+        {
+            "x": {"range": [0, 31], "status": "encrypted", "shape": (3,)},
+            "y": {"range": [0, 31], "status": "encrypted", "shape": (3,)},
+        },
+    ],
+)
+def test_bitwise_or(function, parameters, helpers):
+    """
+    Test bitwise_or where both of the operators are dynamic.
+    """
+
+    parameter_encryption_statuses = helpers.generate_encryption_statuses(parameters)
+    configuration = helpers.configuration()
+
+    compiler = cnp.Compiler(function, parameter_encryption_statuses)
+
+    inputset = helpers.generate_inputset(parameters)
+    circuit = compiler.compile(inputset, configuration)
+
+    sample = helpers.generate_sample(parameters)
+    helpers.check_execution(circuit, function, sample)
+
+
+@pytest.mark.parametrize(
+    "function",
+    [
+        pytest.param(
+            lambda x, y: x & y,
+            id="x & y",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "parameters",
+    [
+        {
+            "x": {"range": [0, 31], "status": "encrypted"},
+            "y": {"range": [0, 31], "status": "encrypted"},
+        },
+        {
+            "x": {"range": [0, 31], "status": "encrypted", "shape": (3,)},
+            "y": {"range": [0, 31], "status": "encrypted", "shape": (3,)},
+        },
+    ],
+)
+def test_bitwise_and(function, parameters, helpers):
+    """
+    Test bitwise_and where both of the operators are dynamic.
+    """
+    print(parameters)
+    parameter_encryption_statuses = helpers.generate_encryption_statuses(parameters)
+    configuration = helpers.configuration()
+
+    compiler = cnp.Compiler(function, parameter_encryption_statuses)
+
+    inputset = helpers.generate_inputset(parameters)
+    circuit = compiler.compile(inputset, configuration)
+    sample = helpers.generate_sample(parameters)
+    helpers.check_execution(circuit, function, sample)
+
+
+@pytest.mark.parametrize(
+    "function",
+    [
+        pytest.param(
+            lambda x, y: x ^ y,
+            id="x ^ y",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "parameters",
+    [
+        {
+            "x": {"range": [0, 31], "status": "encrypted"},
+            "y": {"range": [0, 31], "status": "encrypted"},
+        },
+        {
+            "x": {"range": [0, 31], "status": "encrypted", "shape": (3,)},
+            "y": {"range": [0, 31], "status": "encrypted", "shape": (3,)},
+        },
+        {
+            "x": {"range": [0, 255], "status": "encrypted"},
+            "y": {"range": [0, 255], "status": "encrypted"},
+        },
+    ],
+)
+def test_bitwise_xor(function, parameters, helpers):
+    """
+    Test bitwise_xor where both of the operators are dynamic.
+    """
+
+    parameter_encryption_statuses = helpers.generate_encryption_statuses(parameters)
+    configuration = helpers.configuration()
+
+    compiler = cnp.Compiler(function, parameter_encryption_statuses)
+
+    inputset = helpers.generate_inputset(parameters)
+    circuit = compiler.compile(inputset, configuration)
+    sample = helpers.generate_sample(parameters)
+    helpers.check_execution(circuit, function, sample)

--- a/tests/execution/test_comparisons.py
+++ b/tests/execution/test_comparisons.py
@@ -1,0 +1,407 @@
+"""
+Tests of execution of comparisons operation.
+"""
+
+import pytest
+
+import concrete.numpy as cnp
+
+
+@pytest.mark.parametrize(
+    "function",
+    [
+        pytest.param(
+            lambda x, y: x == y,
+            id="x == y",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "parameters",
+    [
+        {
+            "x": {"range": [0, 255], "status": "encrypted"},
+            "y": {"range": [0, 255], "status": "encrypted"},
+        },
+        {
+            "x": {"range": [-128, 127], "status": "encrypted"},
+            "y": {"range": [-128, 127], "status": "encrypted"},
+        },
+        {
+            "x": {"range": [-128, 127], "status": "encrypted"},
+            "y": {"range": [0, 255], "status": "encrypted"},
+        },
+        {
+            "x": {"range": [0, 255], "status": "encrypted"},
+            "y": {"range": [-128, 127], "status": "encrypted"},
+        },
+        {
+            "x": {"range": [0, 15], "status": "encrypted", "shape": (2,)},
+            "y": {"range": [0, 15], "status": "encrypted", "shape": (2,)},
+        },
+    ],
+)
+def test_equal(function, parameters, helpers):
+    """
+    Test equal where both of the operators are dynamic.
+    """
+
+    parameter_encryption_statuses = helpers.generate_encryption_statuses(parameters)
+    configuration = helpers.configuration()
+
+    compiler = cnp.Compiler(function, parameter_encryption_statuses)
+
+    inputset = helpers.generate_inputset(parameters)
+    circuit = compiler.compile(inputset, configuration)
+
+    sample = helpers.generate_sample(parameters)
+    helpers.check_execution(circuit, function, sample)
+
+
+@pytest.mark.parametrize(
+    "function",
+    [
+        pytest.param(
+            lambda x, y: x != y,
+            id="x != y",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "parameters",
+    [
+        {
+            "x": {"range": [0, 255], "status": "encrypted"},
+            "y": {"range": [0, 255], "status": "encrypted"},
+        },
+        {
+            "x": {"range": [-128, 127], "status": "encrypted"},
+            "y": {"range": [-128, 127], "status": "encrypted"},
+        },
+        {
+            "x": {"range": [-128, 127], "status": "encrypted"},
+            "y": {"range": [0, 255], "status": "encrypted"},
+        },
+        {
+            "x": {"range": [0, 255], "status": "encrypted"},
+            "y": {"range": [-128, 127], "status": "encrypted"},
+        },
+        {
+            "x": {"range": [0, 15], "status": "encrypted", "shape": (2,)},
+            "y": {"range": [0, 15], "status": "encrypted", "shape": (2,)},
+        },
+    ],
+)
+def test_not_equal(function, parameters, helpers):
+    """
+    Test not equal where both of the operators are dynamic.
+    """
+
+    parameter_encryption_statuses = helpers.generate_encryption_statuses(parameters)
+    configuration = helpers.configuration()
+
+    compiler = cnp.Compiler(function, parameter_encryption_statuses)
+
+    inputset = helpers.generate_inputset(parameters)
+    circuit = compiler.compile(inputset, configuration)
+
+    sample = helpers.generate_sample(parameters)
+    helpers.check_execution(circuit, function, sample)
+
+
+@pytest.mark.parametrize(
+    "function",
+    [
+        pytest.param(
+            lambda x, y: x < y,
+            id="x < y",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "parameters",
+    [
+        {
+            "x": {"range": [0, 255], "status": "encrypted"},
+            "y": {"range": [0, 255], "status": "encrypted"},
+        },
+        {
+            "x": {"range": [-128, 127], "status": "encrypted"},
+            "y": {"range": [-128, 127], "status": "encrypted"},
+        },
+        {
+            "x": {"range": [-128, 127], "status": "encrypted"},
+            "y": {"range": [0, 255], "status": "encrypted"},
+        },
+        {
+            "x": {"range": [0, 255], "status": "encrypted"},
+            "y": {"range": [-128, 127], "status": "encrypted"},
+        },
+        {
+            "x": {"range": [0, 1], "status": "encrypted"},
+            "y": {"range": [0, 1], "status": "encrypted"},
+        },
+        {
+            "x": {"range": [0, 15], "status": "encrypted", "shape": (2,)},
+            "y": {"range": [0, 15], "status": "encrypted", "shape": (2,)},
+        },
+        {
+            "x": {"range": [-2, 4], "status": "encrypted", "shape": (2,)},
+            "y": {"range": [0, 15], "status": "encrypted", "shape": (2,)},
+        },
+    ],
+)
+def test_less(function, parameters, helpers):
+    """
+    Test less where both of the operators are dynamic.
+    """
+
+    parameter_encryption_statuses = helpers.generate_encryption_statuses(parameters)
+    configuration = helpers.configuration()
+
+    compiler = cnp.Compiler(function, parameter_encryption_statuses)
+
+    inputset = helpers.generate_inputset(parameters)
+    circuit = compiler.compile(inputset, configuration)
+
+    sample = helpers.generate_sample(parameters)
+    helpers.check_execution(circuit, function, sample)
+
+
+@pytest.mark.parametrize(
+    "function",
+    [
+        pytest.param(
+            lambda x, y: x <= y,
+            id="x <= y",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "parameters",
+    [
+        {
+            "x": {"range": [0, 255], "status": "encrypted"},
+            "y": {"range": [0, 255], "status": "encrypted"},
+        },
+        {
+            "x": {"range": [-128, 127], "status": "encrypted"},
+            "y": {"range": [-128, 127], "status": "encrypted"},
+        },
+        {
+            "x": {"range": [-128, 127], "status": "encrypted"},
+            "y": {"range": [0, 255], "status": "encrypted"},
+        },
+        {
+            "x": {"range": [0, 255], "status": "encrypted"},
+            "y": {"range": [-128, 127], "status": "encrypted"},
+        },
+        {
+            "x": {"range": [0, 15], "status": "encrypted", "shape": (2,)},
+            "y": {"range": [0, 15], "status": "encrypted", "shape": (2,)},
+        },
+    ],
+)
+def test_less_equal(function, parameters, helpers):
+    """
+    Test less equal where both of the operators are dynamic.
+    """
+
+    parameter_encryption_statuses = helpers.generate_encryption_statuses(parameters)
+    configuration = helpers.configuration()
+
+    compiler = cnp.Compiler(function, parameter_encryption_statuses)
+
+    inputset = helpers.generate_inputset(parameters)
+    circuit = compiler.compile(inputset, configuration)
+
+    sample = helpers.generate_sample(parameters)
+    helpers.check_execution(circuit, function, sample)
+
+
+@pytest.mark.parametrize(
+    "function",
+    [
+        pytest.param(
+            lambda x, y: x > y,
+            id="x > y",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "parameters",
+    [
+        {
+            "x": {"range": [0, 255], "status": "encrypted"},
+            "y": {"range": [0, 255], "status": "encrypted"},
+        },
+        {
+            "x": {"range": [-128, 127], "status": "encrypted"},
+            "y": {"range": [-128, 127], "status": "encrypted"},
+        },
+        {
+            "x": {"range": [-128, 127], "status": "encrypted"},
+            "y": {"range": [0, 255], "status": "encrypted"},
+        },
+        {
+            "x": {"range": [0, 255], "status": "encrypted"},
+            "y": {"range": [-128, 127], "status": "encrypted"},
+        },
+        {
+            "x": {"range": [0, 15], "status": "encrypted", "shape": (2,)},
+            "y": {"range": [0, 15], "status": "encrypted", "shape": (2,)},
+        },
+    ],
+)
+def test_greater(function, parameters, helpers):
+    """
+    Test greater where both of the operators are dynamic.
+    """
+
+    parameter_encryption_statuses = helpers.generate_encryption_statuses(parameters)
+    configuration = helpers.configuration()
+
+    compiler = cnp.Compiler(function, parameter_encryption_statuses)
+
+    inputset = helpers.generate_inputset(parameters)
+    circuit = compiler.compile(inputset, configuration)
+
+    sample = helpers.generate_sample(parameters)
+    helpers.check_execution(circuit, function, sample)
+
+
+@pytest.mark.parametrize(
+    "function",
+    [
+        pytest.param(
+            lambda x, y: x >= y,
+            id="x >= y",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "parameters",
+    [
+        {
+            "x": {"range": [0, 255], "status": "encrypted"},
+            "y": {"range": [0, 255], "status": "encrypted"},
+        },
+        {
+            "x": {"range": [-128, 127], "status": "encrypted"},
+            "y": {"range": [-128, 127], "status": "encrypted"},
+        },
+        {
+            "x": {"range": [-128, 127], "status": "encrypted"},
+            "y": {"range": [0, 255], "status": "encrypted"},
+        },
+        {
+            "x": {"range": [0, 255], "status": "encrypted"},
+            "y": {"range": [-128, 127], "status": "encrypted"},
+        },
+        {
+            "x": {"range": [0, 15], "status": "encrypted", "shape": (2,)},
+            "y": {"range": [0, 15], "status": "encrypted", "shape": (2,)},
+        },
+    ],
+)
+def test_greater_equal(function, parameters, helpers):
+    """
+    Test greater equal where both of the operators are dynamic.
+    """
+
+    parameter_encryption_statuses = helpers.generate_encryption_statuses(parameters)
+    configuration = helpers.configuration()
+
+    compiler = cnp.Compiler(function, parameter_encryption_statuses)
+
+    inputset = helpers.generate_inputset(parameters)
+    circuit = compiler.compile(inputset, configuration)
+
+    sample = helpers.generate_sample(parameters)
+    helpers.check_execution(circuit, function, sample)
+
+
+@pytest.mark.parametrize(
+    "function",
+    [
+        pytest.param(
+            lambda x, y: x < y,
+            id="x < y",
+        ),
+        pytest.param(
+            lambda x, y: x <= y,
+            id="x <= y",
+        ),
+        pytest.param(
+            lambda x, y: x > y,
+            id="x > y",
+        ),
+        pytest.param(
+            lambda x, y: x >= y,
+            id="x >= y",
+        ),
+        pytest.param(
+            lambda x, y: x == y,
+            id="x == y",
+        ),
+        pytest.param(
+            lambda x, y: x != y,
+            id="x != y",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "parameters",
+    [
+        {
+            "x": {"range": [-4, 3], "status": "encrypted"},
+            "y": {"range": [0, 7], "status": "encrypted"},
+        },
+        {
+            "x": {"range": [-4, 3], "status": "encrypted"},
+            "y": {"range": [-4, 3], "status": "encrypted"},
+        },
+        {
+            "x": {"range": [0, 7], "status": "encrypted"},
+            "y": {"range": [-4, 3], "status": "encrypted"},
+        },
+        {
+            "x": {"range": [0, 7], "status": "encrypted"},
+            "y": {"range": [0, 7], "status": "encrypted"},
+        },
+        {
+            "x": {"range": [-2, 1], "status": "encrypted"},
+            "y": {"range": [0, 3], "status": "encrypted"},
+        },
+        {
+            "x": {"range": [-2, 1], "status": "encrypted"},
+            "y": {"range": [-2, 1], "status": "encrypted"},
+        },
+        {
+            "x": {"range": [0, 3], "status": "encrypted"},
+            "y": {"range": [-2, 1], "status": "encrypted"},
+        },
+        {
+            "x": {"range": [0, 3], "status": "encrypted"},
+            "y": {"range": [0, 3], "status": "encrypted"},
+        },
+    ],
+)
+def _test_full_coverage(function, parameters, helpers):
+    """
+    Test comparisons where both of the operators are dynamic.
+
+    Uncomment when improving on the algorithms as the test is slow
+    but covers all cases.
+    """
+
+    parameter_encryption_statuses = helpers.generate_encryption_statuses(parameters)
+    configuration = helpers.configuration()
+
+    compiler = cnp.Compiler(function, parameter_encryption_statuses)
+
+    inputset = helpers.generate_inputset(parameters)
+    circuit = compiler.compile(inputset, configuration)
+
+    for args in set(inputset):
+        helpers.check_execution(circuit, function, list(args))

--- a/tests/execution/test_shifts.py
+++ b/tests/execution/test_shifts.py
@@ -1,0 +1,167 @@
+"""
+Tests of execution of shifts operation.
+"""
+
+import pytest
+
+import concrete.numpy as cnp
+
+
+@pytest.mark.parametrize(
+    "function",
+    [
+        pytest.param(
+            lambda x, y: x << y,
+            id="x << y",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "parameters",
+    [
+        {
+            "x": {"range": [0, 1], "status": "encrypted"},
+            "y": {"range": [0, 7], "status": "encrypted"},
+        },
+        {
+            "x": {"range": [0, 3], "status": "encrypted", "shape": (2,)},
+            "y": {"range": [0, 3], "status": "encrypted", "shape": (2,)},
+        },
+    ],
+)
+def _test_left_shift_coverage(function, parameters, helpers):
+    """
+    Test left shift where both of the operators are dynamic.
+    """
+
+    parameter_encryption_statuses = helpers.generate_encryption_statuses(parameters)
+    configuration = helpers.configuration()
+
+    compiler = cnp.Compiler(function, parameter_encryption_statuses)
+
+    inputset = helpers.generate_inputset(parameters)
+    circuit = compiler.compile(inputset, configuration)
+
+    sample = helpers.generate_sample(parameters)
+    helpers.check_execution(circuit, function, sample)
+
+
+@pytest.mark.parametrize(
+    "function",
+    [
+        pytest.param(
+            lambda x, y: x >> y,
+            id="x >> y",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "parameters",
+    [
+        {
+            "x": {"range": [0, 1 << 7], "status": "encrypted"},
+            "y": {"range": [0, 7], "status": "encrypted"},
+        },
+        {
+            "x": {"range": [0, 1 << 4], "status": "encrypted", "shape": (2,)},
+            "y": {"range": [0, 3], "status": "encrypted", "shape": (2,)},
+        },
+    ],
+)
+def test_left_shift(function, parameters, helpers):
+    """
+    Test right shift where both of the operators are dynamic.
+    """
+
+    parameter_encryption_statuses = helpers.generate_encryption_statuses(parameters)
+    configuration = helpers.configuration()
+
+    compiler = cnp.Compiler(function, parameter_encryption_statuses)
+
+    inputset = helpers.generate_inputset(parameters)
+    circuit = compiler.compile(inputset, configuration)
+
+    sample = helpers.generate_sample(parameters)
+    helpers.check_execution(circuit, function, sample)
+
+
+@pytest.mark.parametrize(
+    "function",
+    [
+        pytest.param(
+            lambda x, y: x << y,
+            id="x << y",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "parameters",
+    [
+        {
+            "x": {"range": [0, 1], "status": "encrypted"},
+            "y": {"range": [0, 7], "status": "encrypted"},
+        },
+    ],
+)
+def test_left_shift_coverage(function, parameters, helpers):
+    """
+    Test left shift where both of the operators are dynamic.
+    """
+
+    parameter_encryption_statuses = helpers.generate_encryption_statuses(parameters)
+    configuration = helpers.configuration()
+
+    compiler = cnp.Compiler(function, parameter_encryption_statuses)
+
+    inputset = helpers.generate_inputset(parameters)
+    circuit = compiler.compile(inputset, configuration)
+
+    helpers.check_execution(circuit, function, [1, 0])
+    helpers.check_execution(circuit, function, [1, 1])
+    helpers.check_execution(circuit, function, [1, 2])
+    helpers.check_execution(circuit, function, [1, 3])
+    helpers.check_execution(circuit, function, [1, 4])
+    helpers.check_execution(circuit, function, [1, 5])
+    helpers.check_execution(circuit, function, [1, 6])
+    helpers.check_execution(circuit, function, [1, 7])
+
+
+@pytest.mark.parametrize(
+    "function",
+    [
+        pytest.param(
+            lambda x, y: x >> y,
+            id="x >> y",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "parameters",
+    [
+        {
+            "x": {"range": [0, 1 << 7], "status": "encrypted"},
+            "y": {"range": [0, 7], "status": "encrypted"},
+        },
+    ],
+)
+def test_right_shift_coverage(function, parameters, helpers):
+    """
+    Test right shift where both of the operators are dynamic.
+    """
+
+    parameter_encryption_statuses = helpers.generate_encryption_statuses(parameters)
+    configuration = helpers.configuration()
+
+    compiler = cnp.Compiler(function, parameter_encryption_statuses)
+
+    inputset = helpers.generate_inputset(parameters)
+    circuit = compiler.compile(inputset, configuration)
+
+    helpers.check_execution(circuit, function, [0b11, 0])
+    helpers.check_execution(circuit, function, [0b11, 1])
+    helpers.check_execution(circuit, function, [0b110, 2])
+    helpers.check_execution(circuit, function, [0b1100, 3])
+    helpers.check_execution(circuit, function, [0b11000, 4])
+    helpers.check_execution(circuit, function, [0b110000, 5])
+    helpers.check_execution(circuit, function, [0b110000, 6])
+    helpers.check_execution(circuit, function, [0b1100000, 7])


### PR DESCRIPTION
This PR is a solution for the following bounties:
- [Bitwise shift operators](https://github.com/zama-ai/bounty-program/blob/main/Bounties/Solved/add-bitwise-shift-operations.md)
- [Comparison operators](https://github.com/zama-ai/bounty-program/blob/main/Bounties/Solved/add-comparison-operations.md)
- [Bitwise operations](https://github.com/zama-ai/bounty-program/blob/main/Bounties/Solved/add-bitwise-operations.md)


Implementations of these operands are done by lowering the corresponding node to several MLIR nodes.

**Notes about comparisons:**
Comparions between signed and unsigned integers are supported. In the case where at least one of the two operands is negative, both operands are offset by `bit_width/2` (where `bit_width` is the bit width of the operands), compared as unsigned and if the other operand is signed the result is adjusted if it is greater than `bit_width/2`.

**Notes about bitwise shifts**
Bitwise shifts are using the following logic. We'll only look at `x << b` where `0 <= b < 16` (`x >> b` is derived in a similar way).
First, it is important to notice that 
`x << b = ((b & 0b1000) ? x << 8 : 0) + ((b & 0b0100) ? x << 4 : 0)+ ((b & 0b0010) ? x << 2 : 0) + ((b & 0b0001) ? x << 1 : 0)`

Now we can notice that if by writing `y =  (b & 0b1000 > 0) * ((x << 8) - x) + x`, then:
- if `b&0b10000 > 0` is 1, `y =  1 * ((x << 8) - x) + x = (x << 8) - x + x = x << 8`
- otherwise `y = 0 * ((x << 8) - x) + x = x`. 

The operation `(x << 8) - x` will not overflow as `(x << 8) >= x`.


**Optimisations of LUT generation**
Several luts are used accross my solution to isolate bit groups of fixed size. When the input operand is small enough, this LUT can omitted. This is automatically done by the function `_1d_lut` as it only lower non-identity `LUT` to MLIR.


**Configuration of the chunk size**
All of the operations rely on splitting the input operand in bit-chunks of a fixed length. This length is for now set as `2`, but can be set in the compiler configuration by setting the parameter `split_in_n_group_of_bits` in the `node_converter_configuration` to the desired length.

